### PR TITLE
Updated Makefile to be able to select from the make which platform to build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,9 +3,9 @@ REPO := envplate
 USER := kreuzwerker
 VERSION := "v0.0.4"
 
-build: mac linux
+build: darwin linux
 
-mac:
+darwin:
 	mkdir -p out/darwin
 	GOOS=darwin go build -o out/darwin/ep -ldflags "-X main.build `git rev-parse --short HEAD`" bin/envplate.go
 linux:

--- a/Makefile
+++ b/Makefile
@@ -3,11 +3,14 @@ REPO := envplate
 USER := kreuzwerker
 VERSION := "v0.0.4"
 
-build:
-	mkdir -p out/darwin out/linux
-	GOOS=darwin go build -o out/darwin/ep -ldflags "-X main.build `git rev-parse --short HEAD`" bin/envplate.go
-	GOOS=linux go build -o out/linux/ep -ldflags "-X main.build `git rev-parse --short HEAD`" bin/envplate.go
+build: mac linux
 
+mac:
+	mkdir -p out/darwin
+	GOOS=darwin go build -o out/darwin/ep -ldflags "-X main.build `git rev-parse --short HEAD`" bin/envplate.go
+linux:
+	mkdir -p out/linux
+	GOOS=linux go build -o out/linux/ep -ldflags "-X main.build `git rev-parse --short HEAD`" bin/envplate.go
 clean:
 	rm -rf out
 


### PR DESCRIPTION
Sometimes it is nice to select from the make with platform to target. A very small makefile update to allow this.