### PR TITLE
Allow empty default values - solves #19

### DIFF
--- a/envplate.go
+++ b/envplate.go
@@ -13,9 +13,10 @@ import (
 const (
 	NoDefaultDefined    = ""
 	NotAnEscapeSequence = ""
+	DefaultValueSyntax  = ":-"
 )
 
-var exp = regexp.MustCompile(`(\\*)\$\{(.+?)(?:\:\-(.+?))?\}`)
+var exp = regexp.MustCompile(`(\\*)\$\{(.+?)(?:(\:\-)(.*?))?\}`)
 
 func Apply(globs []string) {
 
@@ -95,7 +96,7 @@ func parse(file string) error {
 	parsed := exp.ReplaceAllStringFunc(string(content), func(match string) string {
 
 		var (
-			esc, key, def     = capture(match)
+			esc, key, sep, def     = capture(match)
 			value, keyDefined = env[key]
 		)
 
@@ -115,7 +116,7 @@ func parse(file string) error {
 
 		if !keyDefined {
 
-			if def == NoDefaultDefined {
+			if sep == NoDefaultDefined {
 				Log(ERROR, "'%s' requires undeclared environment variable '%s', no default is given", file, key)
 			} else {
 
@@ -162,15 +163,16 @@ func parse(file string) error {
 
 }
 
-func capture(s string) (esc, key, def string) {
+func capture(s string) (esc, key, sep, def string) {
 
 	matches := exp.FindStringSubmatch(s)
 
 	esc = matches[1]
 	key = matches[2]
-	def = matches[3]
+	sep = matches[3]
+	def = matches[4]
 
-	return esc, key, def
+	return esc, key, sep, def
 
 }
 


### PR DESCRIPTION
Allow empty default values:

* Change regexp part for parsing default values to allow zero-or-more (so far
  was one-or-more); keep the prefer-less flag
* Make the regexp part for default value syntax a capturing group: ````(\:\-)````
* Add an additional "separator" parameter to the capture function to see
  whether the default value separator was used
* Add a corresponding constant ````DefaultValueSyntax```` with the separator value (````":-"````)
* Change the logic for testing whether a default value was provided to check
  whether the separator is non-empty.
* TEST: adjust ````TestCapture```` accordingly to also handle separator values
* TEST: test the newly supported empty-default-value syntax in ````TestFullParseDefaults```` function