### PR TITLE
Move output to stdout

### DIFF
--- a/envplate.go
+++ b/envplate.go
@@ -96,8 +96,8 @@ func parse(file string) error {
 	parsed := exp.ReplaceAllStringFunc(string(content), func(match string) string {
 
 		var (
-			esc, key, sep, def     = capture(match)
-			value, keyDefined = env[key]
+			esc, key, sep, def = capture(match)
+			value, keyDefined  = env[key]
 		)
 
 		if len(esc)%2 == 1 {
@@ -142,7 +142,10 @@ func parse(file string) error {
 	})
 
 	if Config.DryRun {
-		Log(INFO, "Expanding all references in '%s' would look like this:\n%s", file, parsed)
+		Log(INFO, "Successfully expanding all references into stdout")
+
+		fmt.Print(parsed)
+
 	} else {
 
 		if Config.Backup {


### PR DESCRIPTION
`-d` option says output to `stdout` but actully output to `stderr`,
This PR fixed it and [support redirect to file ](https://github.com/kreuzwerker/envplate/issues/17)using
```
ep -d conf.tpl > conf.tpl
```