### PR TITLE
Changed log level for a message

### DIFF
--- a/envplate.go
+++ b/envplate.go
@@ -118,7 +118,7 @@ func (h *Handler) parse(file string) error {
 	})
 
 	if h.DryRun {
-		Log(INFO, "Expanding all references in '%s' without doing anything (dry-run)", file)
+		Log(DEBUG, "Expanding all references in '%s' without doing anything (dry-run)", file)
 		Log(RAW, parsed)
 	} else {
 


### PR DESCRIPTION
helpful if you'd want to save dryrun to some other file e.g.
`ep -d /etc/nginx/nginx.conf 2> /etc/nginx/nginx.test.conf`
currently this would generate file like 
```
2018/06/18 12:45:41 [ INFO ] Expanding all references in '/etc/nginx/nginx.conf' would look like this:
events {
    worker_connections 768;
}
error_log /dev/stdout info;
http {
.....
```
with this pull request message `Expanding all references in` should only appear if `-v`