### PR TITLE
Do not modify files if parsing fails

### DIFF
--- a/envplate.go
+++ b/envplate.go
@@ -117,6 +117,10 @@ func (h *Handler) parse(file string) error {
 
 	})
 
+	if len(errors) > 0 {
+		return errors[0]
+	}
+
 	if h.DryRun {
 		Log(DEBUG, "Expanding all references in '%s' without doing anything (dry-run)", file)
 		Log(RAW, parsed)
@@ -142,10 +146,6 @@ func (h *Handler) parse(file string) error {
 			return err
 		}
 
-	}
-
-	if len(errors) > 0 {
-		return errors[0]
 	}
 
 	return nil

--- a/envplate_test.go
+++ b/envplate_test.go
@@ -229,11 +229,30 @@ func TestStrictParse(t *testing.T) {
 		file = "test/template4.txt"
 	)
 
-	defer _restore(file)
-
 	err := handler.parse(file)
 	assert.Error(err)
 
 	assert.Equal("'test/template4.txt' requires undeclared environment variable 'ANOTHER_DATABASE', but cannot use default 'db2.example.com' (strict-mode)", err.Error())
+
+}
+
+func TestAbortOnParseErrors(t *testing.T) {
+
+	assert := assert.New(t)
+	handler := &Handler{
+		Backup: true,
+		Strict: true,
+	}
+
+	var (
+		file     = "test/template4.txt"
+		template = _read(t, file)
+	)
+
+	err := handler.parse(file)
+	assert.Error(err)
+
+	assert.Equal(template, _read(t, file))
+	assert.NoFileExists(fmt.Sprintf("%s.bak", file))
 
 }


### PR DESCRIPTION
<!-- Thank you for your contribution to envplate! Please replace {Please write here} with your description -->


## What does this do / why do we need it?

Consider the following example:

```
$ cat file
${UNDECLARED}
$ ep file
2024/03/05 21:33:31 [ ERROR ] 'file' requires undeclared environment variable 'UNDECLARED', no default is given
2024/03/05 21:33:31 [ ERROR ] Error while parsing 'file': 'file' requires undeclared environment variable 'UNDECLARED', no default is give
$ echo $?
1
$ cat file

$
```

I would expect the file to **not** be modified since the command resulted in an error.

## How this PR fixes the problem?

The proposed change aborts writing the modified buffer if any errors occurred.

## What should your reviewer look out for in this PR?

N/A

## Check lists

* [x] Test passed
* [x] Coding style (indentation, etc)


## Additional Comments (if any)

N/A


## Which issue(s) does this PR fix?

N/A
